### PR TITLE
Add iframe preview sub-slides for all courses

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,38 +39,34 @@
               <li><a href="https://www.epicreact.dev/">Epic React</a></li>
             </ul>
           </section>
-          <section data-background-iframe="https://www.epicweb.dev/" data-background-interactive>
-            <div style="position: absolute; bottom: 20px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,0.75); padding: 8px 20px; border-radius: 6px; white-space: nowrap;">
-              <p style="margin: 0; font-size: 0.8em;">Epic Web</p>
-            </div>
+          <section>
+            <h3>Epic Web</h3>
           </section>
-          <section data-background-iframe="https://www.epicreact.dev/" data-background-interactive>
-            <div style="position: absolute; bottom: 20px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,0.75); padding: 8px 20px; border-radius: 6px; white-space: nowrap;">
-              <p style="margin: 0; font-size: 0.8em;">Epic React</p>
-            </div>
+          <section data-background-iframe="https://www.epicweb.dev/" data-background-interactive></section>
+          <section>
+            <h3>Epic React</h3>
           </section>
+          <section data-background-iframe="https://www.epicreact.dev/" data-background-interactive></section>
           <section>
             <h3>Josh W. Comeau</h3>
             <ul>
               <li><a href="https://www.joyofreact.com/">Joy of React</a></li>
             </ul>
           </section>
-          <section data-background-iframe="https://www.joyofreact.com/" data-background-interactive>
-            <div style="position: absolute; bottom: 20px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,0.75); padding: 8px 20px; border-radius: 6px; white-space: nowrap;">
-              <p style="margin: 0; font-size: 0.8em;">Joy of React</p>
-            </div>
+          <section>
+            <h3>Joy of React</h3>
           </section>
+          <section data-background-iframe="https://www.joyofreact.com/" data-background-interactive></section>
           <section>
             <h3>Tyler McGinnis</h3>
             <ul>
               <li><a href="https://react.gg/">React.gg</a></li>
             </ul>
           </section>
-          <section data-background-iframe="https://react.gg/" data-background-interactive>
-            <div style="position: absolute; bottom: 20px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,0.75); padding: 8px 20px; border-radius: 6px; white-space: nowrap;">
-              <p style="margin: 0; font-size: 0.8em;">React.gg</p>
-            </div>
+          <section>
+            <h3>React.gg</h3>
           </section>
+          <section data-background-iframe="https://react.gg/" data-background-interactive></section>
         </section>
         <section>
           <section>
@@ -82,22 +78,20 @@
               <li><a href="https://css-for-js.dev/">CSS for JS</a></li>
             </ul>
           </section>
-          <section data-background-iframe="https://css-for-js.dev/" data-background-interactive>
-            <div style="position: absolute; bottom: 20px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,0.75); padding: 8px 20px; border-radius: 6px; white-space: nowrap;">
-              <p style="margin: 0; font-size: 0.8em;">CSS for JS</p>
-            </div>
+          <section>
+            <h3>CSS for JS</h3>
           </section>
+          <section data-background-iframe="https://css-for-js.dev/" data-background-interactive></section>
           <section>
             <h3>Kevin Powell</h3>
             <ul>
               <li><a href="https://thecascade.dev/courses/css-demystified/">CSS Demystified</a></li>
             </ul>
           </section>
-          <section data-background-iframe="https://thecascade.dev/courses/css-demystified/" data-background-interactive>
-            <div style="position: absolute; bottom: 20px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,0.75); padding: 8px 20px; border-radius: 6px; white-space: nowrap;">
-              <p style="margin: 0; font-size: 0.8em;">CSS Demystified</p>
-            </div>
+          <section>
+            <h3>CSS Demystified</h3>
           </section>
+          <section data-background-iframe="https://thecascade.dev/courses/css-demystified/" data-background-interactive></section>
         </section>
         <section>
           <section>
@@ -109,33 +103,30 @@
               <li><a href="https://animations.dev/">animations.dev</a></li>
             </ul>
           </section>
-          <section data-background-iframe="https://animations.dev/" data-background-interactive>
-            <div style="position: absolute; bottom: 20px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,0.75); padding: 8px 20px; border-radius: 6px; white-space: nowrap;">
-              <p style="margin: 0; font-size: 0.8em;">animations.dev</p>
-            </div>
+          <section>
+            <h3>animations.dev</h3>
           </section>
+          <section data-background-iframe="https://animations.dev/" data-background-interactive></section>
           <section>
             <h3>Nanda Sayhrasyad</h3>
             <ul>
               <li><a href="https://www.svg.guide/">SVG Guide</a></li>
             </ul>
           </section>
-          <section data-background-iframe="https://www.svg.guide/" data-background-interactive>
-            <div style="position: absolute; bottom: 20px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,0.75); padding: 8px 20px; border-radius: 6px; white-space: nowrap;">
-              <p style="margin: 0; font-size: 0.8em;">SVG Guide</p>
-            </div>
+          <section>
+            <h3>SVG Guide</h3>
           </section>
+          <section data-background-iframe="https://www.svg.guide/" data-background-interactive></section>
           <section>
             <h3>Bruno Simon</h3>
             <ul>
               <li><a href="https://threejs-journey.com/">Three.js Journey</a></li>
             </ul>
           </section>
-          <section data-background-iframe="https://threejs-journey.com/" data-background-interactive>
-            <div style="position: absolute; bottom: 20px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,0.75); padding: 8px 20px; border-radius: 6px; white-space: nowrap;">
-              <p style="margin: 0; font-size: 0.8em;">Three.js Journey</p>
-            </div>
+          <section>
+            <h3>Three.js Journey</h3>
           </section>
+          <section data-background-iframe="https://threejs-journey.com/" data-background-interactive></section>
         </section>
         <section>
           <section>
@@ -148,17 +139,29 @@
             </ul>
           </section>
           <section>
+            <h3>Total TypeScript</h3>
+          </section>
+          <section data-background-iframe="https://www.totaltypescript.com/" data-background-interactive></section>
+          <section>
             <h3>Kyle (Web Dev Simplified)</h3>
             <ul>
               <li><a href="https://courses.webdevsimplified.com/typescript-simplified/">TypeScript Simplified</a></li>
             </ul>
           </section>
           <section>
+            <h3>TypeScript Simplified</h3>
+          </section>
+          <section data-background-iframe="https://courses.webdevsimplified.com/typescript-simplified/" data-background-interactive></section>
+          <section>
             <h3>Kent C. Dodds</h3>
             <ul>
               <li><a href="https://www.epicweb.dev/practical-typescript">Practical TypeScript</a></li>
             </ul>
           </section>
+          <section>
+            <h3>Practical TypeScript</h3>
+          </section>
+          <section data-background-iframe="https://www.epicweb.dev/practical-typescript" data-background-interactive></section>
         </section>
         <section>
           <section>
@@ -171,6 +174,10 @@
             </ul>
           </section>
           <section>
+            <h3>Epic MCP</h3>
+          </section>
+          <section data-background-iframe="https://www.epicai.pro/workshops/epic-mcp-from-scratch-to-production" data-background-interactive></section>
+          <section>
             <h3>Matt Pocock (AiHero)</h3>
             <ul>
               <li><a href="https://www.aihero.dev/workshops/ai-sdk-v6-crash-course">AI SDK v6 Crash Course</a></li>
@@ -179,11 +186,27 @@
             </ul>
           </section>
           <section>
+            <h3>AI SDK v6 Crash Course</h3>
+          </section>
+          <section data-background-iframe="https://www.aihero.dev/workshops/ai-sdk-v6-crash-course" data-background-interactive></section>
+          <section>
+            <h3>Build Your Own AI Personal Assistant in TypeScript</h3>
+          </section>
+          <section data-background-iframe="https://www.aihero.dev/cohorts/build-your-own-ai-personal-assistant-in-typescript" data-background-interactive></section>
+          <section>
+            <h3>Claude Code for Real Engineers</h3>
+          </section>
+          <section data-background-iframe="https://www.aihero.dev/cohorts/claude-code-for-real-engineers-2026-04" data-background-interactive></section>
+          <section>
             <h3>10xDevs</h3>
             <ul>
               <li><a href="https://www.10xdevs.pl/">10xDevs</a></li>
             </ul>
           </section>
+          <section>
+            <h3>10xDevs</h3>
+          </section>
+          <section data-background-iframe="https://www.10xdevs.pl/" data-background-interactive></section>
         </section>
         <section>
           <section>
@@ -196,11 +219,19 @@
             </ul>
           </section>
           <section>
+            <h3>Testing Accessibility</h3>
+          </section>
+          <section data-background-iframe="https://testingaccessibility.com/" data-background-interactive></section>
+          <section>
             <h3>Sara Soueidan</h3>
             <ul>
               <li><a href="https://practical-accessibility.today/">Practical Accessibility</a></li>
             </ul>
           </section>
+          <section>
+            <h3>Practical Accessibility</h3>
+          </section>
+          <section data-background-iframe="https://practical-accessibility.today/" data-background-interactive></section>
         </section>
         <section>
           <section>
@@ -212,6 +243,10 @@
               <li><a href="https://frontendmasters.com/courses/">Frontend Masters</a></li>
             </ul>
           </section>
+          <section>
+            <h3>Frontend Masters</h3>
+          </section>
+          <section data-background-iframe="https://frontendmasters.com/courses/" data-background-interactive></section>
         </section>
         <section>
           <section>

--- a/index.html
+++ b/index.html
@@ -34,25 +34,15 @@
           </section>
           <section>
             <h3>Kent C. Dodds</h3>
-            <ul>
-              <li><a href="https://www.epicweb.dev/">Epic Web</a></li>
-              <li><a href="https://www.epicreact.dev/">Epic React</a></li>
-            </ul>
           </section>
           <section data-background-iframe="https://www.epicweb.dev/" data-background-interactive></section>
           <section data-background-iframe="https://www.epicreact.dev/" data-background-interactive></section>
           <section>
             <h3>Josh W. Comeau</h3>
-            <ul>
-              <li><a href="https://www.joyofreact.com/">Joy of React</a></li>
-            </ul>
           </section>
           <section data-background-iframe="https://www.joyofreact.com/" data-background-interactive></section>
           <section>
             <h3>Tyler McGinnis</h3>
-            <ul>
-              <li><a href="https://react.gg/">React.gg</a></li>
-            </ul>
           </section>
           <section data-background-iframe="https://react.gg/" data-background-interactive></section>
         </section>
@@ -62,16 +52,10 @@
           </section>
           <section>
             <h3>Josh W. Comeau</h3>
-            <ul>
-              <li><a href="https://css-for-js.dev/">CSS for JS</a></li>
-            </ul>
           </section>
           <section data-background-iframe="https://css-for-js.dev/" data-background-interactive></section>
           <section>
             <h3>Kevin Powell</h3>
-            <ul>
-              <li><a href="https://thecascade.dev/courses/css-demystified/">CSS Demystified</a></li>
-            </ul>
           </section>
           <section data-background-iframe="https://thecascade.dev/courses/css-demystified/" data-background-interactive></section>
         </section>
@@ -81,23 +65,14 @@
           </section>
           <section>
             <h3>Emil Kowalski</h3>
-            <ul>
-              <li><a href="https://animations.dev/">animations.dev</a></li>
-            </ul>
           </section>
           <section data-background-iframe="https://animations.dev/" data-background-interactive></section>
           <section>
             <h3>Nanda Sayhrasyad</h3>
-            <ul>
-              <li><a href="https://www.svg.guide/">SVG Guide</a></li>
-            </ul>
           </section>
           <section data-background-iframe="https://www.svg.guide/" data-background-interactive></section>
           <section>
             <h3>Bruno Simon</h3>
-            <ul>
-              <li><a href="https://threejs-journey.com/">Three.js Journey</a></li>
-            </ul>
           </section>
           <section data-background-iframe="https://threejs-journey.com/" data-background-interactive></section>
         </section>
@@ -107,23 +82,14 @@
           </section>
           <section>
             <h3>Matt Pocock</h3>
-            <ul>
-              <li><a href="https://www.totaltypescript.com/">Total TypeScript</a></li>
-            </ul>
           </section>
           <section data-background-iframe="https://www.totaltypescript.com/" data-background-interactive></section>
           <section>
             <h3>Kyle (Web Dev Simplified)</h3>
-            <ul>
-              <li><a href="https://courses.webdevsimplified.com/typescript-simplified/">TypeScript Simplified</a></li>
-            </ul>
           </section>
           <section data-background-iframe="https://courses.webdevsimplified.com/typescript-simplified/" data-background-interactive></section>
           <section>
             <h3>Kent C. Dodds</h3>
-            <ul>
-              <li><a href="https://www.epicweb.dev/practical-typescript">Practical TypeScript</a></li>
-            </ul>
           </section>
           <section data-background-iframe="https://www.epicweb.dev/practical-typescript" data-background-interactive></section>
         </section>
@@ -133,27 +99,16 @@
           </section>
           <section>
             <h3>Kent C. Dodds</h3>
-            <ul>
-              <li><a href="https://www.epicai.pro/workshops/epic-mcp-from-scratch-to-production">Epic MCP</a></li>
-            </ul>
           </section>
           <section data-background-iframe="https://www.epicai.pro/workshops/epic-mcp-from-scratch-to-production" data-background-interactive></section>
           <section>
             <h3>Matt Pocock (AiHero)</h3>
-            <ul>
-              <li><a href="https://www.aihero.dev/workshops/ai-sdk-v6-crash-course">AI SDK v6 Crash Course</a></li>
-              <li><a href="https://www.aihero.dev/cohorts/build-your-own-ai-personal-assistant-in-typescript">Build Your Own AI Personal Assistant in TypeScript</a></li>
-              <li><a href="https://www.aihero.dev/cohorts/claude-code-for-real-engineers-2026-04">Claude Code for Real Engineers</a></li>
-            </ul>
           </section>
           <section data-background-iframe="https://www.aihero.dev/workshops/ai-sdk-v6-crash-course" data-background-interactive></section>
           <section data-background-iframe="https://www.aihero.dev/cohorts/build-your-own-ai-personal-assistant-in-typescript" data-background-interactive></section>
           <section data-background-iframe="https://www.aihero.dev/cohorts/claude-code-for-real-engineers-2026-04" data-background-interactive></section>
           <section>
             <h3>10xDevs</h3>
-            <ul>
-              <li><a href="https://www.10xdevs.pl/">10xDevs</a></li>
-            </ul>
           </section>
           <section data-background-iframe="https://www.10xdevs.pl/" data-background-interactive></section>
         </section>
@@ -163,16 +118,10 @@
           </section>
           <section>
             <h3>Marcy Sutton Todd</h3>
-            <ul>
-              <li><a href="https://testingaccessibility.com/">Testing Accessibility</a></li>
-            </ul>
           </section>
           <section data-background-iframe="https://testingaccessibility.com/" data-background-interactive></section>
           <section>
             <h3>Sara Soueidan</h3>
-            <ul>
-              <li><a href="https://practical-accessibility.today/">Practical Accessibility</a></li>
-            </ul>
           </section>
           <section data-background-iframe="https://practical-accessibility.today/" data-background-interactive></section>
         </section>
@@ -182,9 +131,6 @@
           </section>
           <section>
             <h3>Frontend Masters</h3>
-            <ul>
-              <li><a href="https://frontendmasters.com/courses/">Frontend Masters</a></li>
-            </ul>
           </section>
           <section data-background-iframe="https://frontendmasters.com/courses/" data-background-interactive></section>
         </section>

--- a/index.html
+++ b/index.html
@@ -82,11 +82,21 @@
               <li><a href="https://css-for-js.dev/">CSS for JS</a></li>
             </ul>
           </section>
+          <section data-background-iframe="https://css-for-js.dev/" data-background-interactive>
+            <div style="position: absolute; bottom: 20px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,0.75); padding: 8px 20px; border-radius: 6px; white-space: nowrap;">
+              <p style="margin: 0; font-size: 0.8em;">CSS for JS</p>
+            </div>
+          </section>
           <section>
             <h3>Kevin Powell</h3>
             <ul>
               <li><a href="https://thecascade.dev/courses/css-demystified/">CSS Demystified</a></li>
             </ul>
+          </section>
+          <section data-background-iframe="https://thecascade.dev/courses/css-demystified/" data-background-interactive>
+            <div style="position: absolute; bottom: 20px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,0.75); padding: 8px 20px; border-radius: 6px; white-space: nowrap;">
+              <p style="margin: 0; font-size: 0.8em;">CSS Demystified</p>
+            </div>
           </section>
         </section>
         <section>

--- a/index.html
+++ b/index.html
@@ -39,13 +39,7 @@
               <li><a href="https://www.epicreact.dev/">Epic React</a></li>
             </ul>
           </section>
-          <section>
-            <h3>Epic Web</h3>
-          </section>
           <section data-background-iframe="https://www.epicweb.dev/" data-background-interactive></section>
-          <section>
-            <h3>Epic React</h3>
-          </section>
           <section data-background-iframe="https://www.epicreact.dev/" data-background-interactive></section>
           <section>
             <h3>Josh W. Comeau</h3>
@@ -53,18 +47,12 @@
               <li><a href="https://www.joyofreact.com/">Joy of React</a></li>
             </ul>
           </section>
-          <section>
-            <h3>Joy of React</h3>
-          </section>
           <section data-background-iframe="https://www.joyofreact.com/" data-background-interactive></section>
           <section>
             <h3>Tyler McGinnis</h3>
             <ul>
               <li><a href="https://react.gg/">React.gg</a></li>
             </ul>
-          </section>
-          <section>
-            <h3>React.gg</h3>
           </section>
           <section data-background-iframe="https://react.gg/" data-background-interactive></section>
         </section>
@@ -78,18 +66,12 @@
               <li><a href="https://css-for-js.dev/">CSS for JS</a></li>
             </ul>
           </section>
-          <section>
-            <h3>CSS for JS</h3>
-          </section>
           <section data-background-iframe="https://css-for-js.dev/" data-background-interactive></section>
           <section>
             <h3>Kevin Powell</h3>
             <ul>
               <li><a href="https://thecascade.dev/courses/css-demystified/">CSS Demystified</a></li>
             </ul>
-          </section>
-          <section>
-            <h3>CSS Demystified</h3>
           </section>
           <section data-background-iframe="https://thecascade.dev/courses/css-demystified/" data-background-interactive></section>
         </section>
@@ -103,9 +85,6 @@
               <li><a href="https://animations.dev/">animations.dev</a></li>
             </ul>
           </section>
-          <section>
-            <h3>animations.dev</h3>
-          </section>
           <section data-background-iframe="https://animations.dev/" data-background-interactive></section>
           <section>
             <h3>Nanda Sayhrasyad</h3>
@@ -113,18 +92,12 @@
               <li><a href="https://www.svg.guide/">SVG Guide</a></li>
             </ul>
           </section>
-          <section>
-            <h3>SVG Guide</h3>
-          </section>
           <section data-background-iframe="https://www.svg.guide/" data-background-interactive></section>
           <section>
             <h3>Bruno Simon</h3>
             <ul>
               <li><a href="https://threejs-journey.com/">Three.js Journey</a></li>
             </ul>
-          </section>
-          <section>
-            <h3>Three.js Journey</h3>
           </section>
           <section data-background-iframe="https://threejs-journey.com/" data-background-interactive></section>
         </section>
@@ -138,9 +111,6 @@
               <li><a href="https://www.totaltypescript.com/">Total TypeScript</a></li>
             </ul>
           </section>
-          <section>
-            <h3>Total TypeScript</h3>
-          </section>
           <section data-background-iframe="https://www.totaltypescript.com/" data-background-interactive></section>
           <section>
             <h3>Kyle (Web Dev Simplified)</h3>
@@ -148,18 +118,12 @@
               <li><a href="https://courses.webdevsimplified.com/typescript-simplified/">TypeScript Simplified</a></li>
             </ul>
           </section>
-          <section>
-            <h3>TypeScript Simplified</h3>
-          </section>
           <section data-background-iframe="https://courses.webdevsimplified.com/typescript-simplified/" data-background-interactive></section>
           <section>
             <h3>Kent C. Dodds</h3>
             <ul>
               <li><a href="https://www.epicweb.dev/practical-typescript">Practical TypeScript</a></li>
             </ul>
-          </section>
-          <section>
-            <h3>Practical TypeScript</h3>
           </section>
           <section data-background-iframe="https://www.epicweb.dev/practical-typescript" data-background-interactive></section>
         </section>
@@ -173,9 +137,6 @@
               <li><a href="https://www.epicai.pro/workshops/epic-mcp-from-scratch-to-production">Epic MCP</a></li>
             </ul>
           </section>
-          <section>
-            <h3>Epic MCP</h3>
-          </section>
           <section data-background-iframe="https://www.epicai.pro/workshops/epic-mcp-from-scratch-to-production" data-background-interactive></section>
           <section>
             <h3>Matt Pocock (AiHero)</h3>
@@ -185,26 +146,14 @@
               <li><a href="https://www.aihero.dev/cohorts/claude-code-for-real-engineers-2026-04">Claude Code for Real Engineers</a></li>
             </ul>
           </section>
-          <section>
-            <h3>AI SDK v6 Crash Course</h3>
-          </section>
           <section data-background-iframe="https://www.aihero.dev/workshops/ai-sdk-v6-crash-course" data-background-interactive></section>
-          <section>
-            <h3>Build Your Own AI Personal Assistant in TypeScript</h3>
-          </section>
           <section data-background-iframe="https://www.aihero.dev/cohorts/build-your-own-ai-personal-assistant-in-typescript" data-background-interactive></section>
-          <section>
-            <h3>Claude Code for Real Engineers</h3>
-          </section>
           <section data-background-iframe="https://www.aihero.dev/cohorts/claude-code-for-real-engineers-2026-04" data-background-interactive></section>
           <section>
             <h3>10xDevs</h3>
             <ul>
               <li><a href="https://www.10xdevs.pl/">10xDevs</a></li>
             </ul>
-          </section>
-          <section>
-            <h3>10xDevs</h3>
           </section>
           <section data-background-iframe="https://www.10xdevs.pl/" data-background-interactive></section>
         </section>
@@ -218,18 +167,12 @@
               <li><a href="https://testingaccessibility.com/">Testing Accessibility</a></li>
             </ul>
           </section>
-          <section>
-            <h3>Testing Accessibility</h3>
-          </section>
           <section data-background-iframe="https://testingaccessibility.com/" data-background-interactive></section>
           <section>
             <h3>Sara Soueidan</h3>
             <ul>
               <li><a href="https://practical-accessibility.today/">Practical Accessibility</a></li>
             </ul>
-          </section>
-          <section>
-            <h3>Practical Accessibility</h3>
           </section>
           <section data-background-iframe="https://practical-accessibility.today/" data-background-interactive></section>
         </section>
@@ -242,9 +185,6 @@
             <ul>
               <li><a href="https://frontendmasters.com/courses/">Frontend Masters</a></li>
             </ul>
-          </section>
-          <section>
-            <h3>Frontend Masters</h3>
           </section>
           <section data-background-iframe="https://frontendmasters.com/courses/" data-background-interactive></section>
         </section>

--- a/index.html
+++ b/index.html
@@ -39,17 +39,37 @@
               <li><a href="https://www.epicreact.dev/">Epic React</a></li>
             </ul>
           </section>
+          <section data-background-iframe="https://www.epicweb.dev/" data-background-interactive>
+            <div style="position: absolute; bottom: 20px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,0.75); padding: 8px 20px; border-radius: 6px; white-space: nowrap;">
+              <p style="margin: 0; font-size: 0.8em;">Epic Web</p>
+            </div>
+          </section>
+          <section data-background-iframe="https://www.epicreact.dev/" data-background-interactive>
+            <div style="position: absolute; bottom: 20px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,0.75); padding: 8px 20px; border-radius: 6px; white-space: nowrap;">
+              <p style="margin: 0; font-size: 0.8em;">Epic React</p>
+            </div>
+          </section>
           <section>
             <h3>Josh W. Comeau</h3>
             <ul>
               <li><a href="https://www.joyofreact.com/">Joy of React</a></li>
             </ul>
           </section>
+          <section data-background-iframe="https://www.joyofreact.com/" data-background-interactive>
+            <div style="position: absolute; bottom: 20px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,0.75); padding: 8px 20px; border-radius: 6px; white-space: nowrap;">
+              <p style="margin: 0; font-size: 0.8em;">Joy of React</p>
+            </div>
+          </section>
           <section>
             <h3>Tyler McGinnis</h3>
             <ul>
               <li><a href="https://react.gg/">React.gg</a></li>
             </ul>
+          </section>
+          <section data-background-iframe="https://react.gg/" data-background-interactive>
+            <div style="position: absolute; bottom: 20px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,0.75); padding: 8px 20px; border-radius: 6px; white-space: nowrap;">
+              <p style="margin: 0; font-size: 0.8em;">React.gg</p>
+            </div>
           </section>
         </section>
         <section>

--- a/index.html
+++ b/index.html
@@ -109,17 +109,32 @@
               <li><a href="https://animations.dev/">animations.dev</a></li>
             </ul>
           </section>
+          <section data-background-iframe="https://animations.dev/" data-background-interactive>
+            <div style="position: absolute; bottom: 20px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,0.75); padding: 8px 20px; border-radius: 6px; white-space: nowrap;">
+              <p style="margin: 0; font-size: 0.8em;">animations.dev</p>
+            </div>
+          </section>
           <section>
             <h3>Nanda Sayhrasyad</h3>
             <ul>
               <li><a href="https://www.svg.guide/">SVG Guide</a></li>
             </ul>
           </section>
+          <section data-background-iframe="https://www.svg.guide/" data-background-interactive>
+            <div style="position: absolute; bottom: 20px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,0.75); padding: 8px 20px; border-radius: 6px; white-space: nowrap;">
+              <p style="margin: 0; font-size: 0.8em;">SVG Guide</p>
+            </div>
+          </section>
           <section>
             <h3>Bruno Simon</h3>
             <ul>
               <li><a href="https://threejs-journey.com/">Three.js Journey</a></li>
             </ul>
+          </section>
+          <section data-background-iframe="https://threejs-journey.com/" data-background-interactive>
+            <div style="position: absolute; bottom: 20px; left: 50%; transform: translateX(-50%); background: rgba(0,0,0,0.75); padding: 8px 20px; border-radius: 6px; white-space: nowrap;">
+              <p style="margin: 0; font-size: 0.8em;">Three.js Journey</p>
+            </div>
           </section>
         </section>
         <section>


### PR DESCRIPTION
## Summary

- Add full-screen iframe preview sub-slide after each creator slide for all 20 courses across React, CSS, Animation, TypeScript, AI, A11y, and Course Platforms sections
- Each creator slide shows only the author name; iframe slides use `data-background-iframe` + `data-background-interactive` for full-screen display

## Test plan

- [ ] Navigate through each section and verify iframe sub-slides appear after each author slide
- [ ] Verify all course URLs load correctly in iframes

resolves #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)